### PR TITLE
Only convert rmd files to md if they have changed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,9 +83,8 @@ HTML_DST = \
 ## lesson-md        : convert Rmarkdown files to markdown
 lesson-md : ${RMD_DST}
 
-# Use of .NOTPARALLEL makes rule execute only once
-${RMD_DST} : ${RMD_SRC}
-	@bin/knit_lessons.sh ${RMD_SRC}
+_episodes/%.md: _episodes_rmd/%.Rmd
+	@bin/knit_lessons.sh $< $@
 
 ## lesson-check     : validate lesson Markdown.
 lesson-check :

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,9 @@ all : commands
 commands :
 	@grep -h -E '^##' ${MAKEFILES} | sed -e 's/## //g'
 
+## serve-rmd        : run a local server, updating Rmd file automatically
+serve-rmd: lesson-md lesson-watchrmd serve
+
 ## serve            : run a local server.
 serve : lesson-md
 	${JEKYLL} serve
@@ -54,7 +57,7 @@ workshop-check :
 ## ----------------------------------------
 ## Commands specific to lesson websites.
 
-.PHONY : lesson-check lesson-md lesson-files lesson-fixme
+.PHONY : lesson-check lesson-md lesson-files lesson-fixme lesson-watchrmd
 
 # RMarkdown files
 RMD_SRC = $(wildcard _episodes_rmd/??-*.Rmd)
@@ -82,6 +85,9 @@ HTML_DST = \
 
 ## lesson-md        : convert Rmarkdown files to markdown
 lesson-md : ${RMD_DST}
+
+lesson-watchrmd:
+	@bin/watchRmd.sh &
 
 _episodes/%.md: _episodes_rmd/%.Rmd
 	@bin/knit_lessons.sh $< $@

--- a/bin/generate_md_episodes.R
+++ b/bin/generate_md_episodes.R
@@ -22,14 +22,17 @@ generate_md_episodes <- function() {
         install.packages(missing_pkgs)
     }
 
-    ## find all the Rmd files, and generate the paths for their respective outputs
-    src_rmd <- list.files(pattern = "??-*.Rmd$", path = "_episodes_rmd", full.names = TRUE)
-    dest_md <- file.path("_episodes", gsub("Rmd$", "md", basename(src_rmd)))
+    ## get the Rmd file to process from the command line, and generate the path for their respective outputs
+    args  <- commandArgs(trailingOnly = TRUE)
+    if (length(args) != 2){
+	    stop("input and output file must be passed to the script")
+    }
+
+    src_rmd <- args[1]
+    dest_md <- args[2]
 
     ## knit the Rmd into markdown
-    mapply(function(x, y) {
-        knitr::knit(x, output = y)
-    }, src_rmd, dest_md)
+    knitr::knit(src_rmd, output = dest_md)
 
 }
 

--- a/bin/generate_md_episodes.R
+++ b/bin/generate_md_episodes.R
@@ -24,12 +24,20 @@ generate_md_episodes <- function() {
 
     ## get the Rmd file to process from the command line, and generate the path for their respective outputs
     args  <- commandArgs(trailingOnly = TRUE)
-    if (length(args) != 2){
-	    stop("input and output file must be passed to the script")
-    }
 
-    src_rmd <- args[1]
-    dest_md <- args[2]
+    if(length(args) == 1){
+	       src_rmd  <- args[1]
+	       dest_md  <- paste0("_episodes/",
+				  basename(tools::file_path_sans_ext(src_rmd)),
+				  ".md")
+
+    }
+    else if(length(args) == 2){
+	    src_rmd <- args[1]
+	    dest_md <- args[2] 
+    }else{
+	    stop("input [and output] file must be passed to the script")
+    }
 
     ## knit the Rmd into markdown
     knitr::knit(src_rmd, output = dest_md)

--- a/bin/knit_lessons.sh
+++ b/bin/knit_lessons.sh
@@ -4,5 +4,5 @@
 # The Makefile passes in the names of files.
 
 if [ $# -ne 0 ] ; then
-    Rscript -e "source('bin/generate_md_episodes.R')"
+    Rscript -e "source('bin/generate_md_episodes.R')" $*
 fi

--- a/bin/watchRmd.sh
+++ b/bin/watchRmd.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+while inotifywait -e close_write  _episodes_rmd/*.Rmd; do make lesson-md; done
+

--- a/bin/watchRmd.sh
+++ b/bin/watchRmd.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-while fswatch --event=Updated _episodes_rmd/*.Rmd; do make lesson-md; done
+fswatch --event=Updated _episodes_rmd/*.Rmd | make lesson-md
 

--- a/bin/watchRmd.sh
+++ b/bin/watchRmd.sh
@@ -1,3 +1,13 @@
 #!/bin/bash
-fswatch --event=Updated _episodes_rmd/*.Rmd | make lesson-md
+
+if command -v fswatch >/dev/null 2>&1 ; then
+	watchcmd="fswatch --event Updated "
+elif command -v inotifywait >/dev/null 2>&1; then
+	watchcmd="inotifywait --format=%w -q -m -e close_write "
+else
+	echo "Cannot find fswatch or inotifywait"
+	exit 1
+fi
+echo $watchcmd
+$watchcmd _episodes_rmd/*.Rmd |xargs -n 1 Rscript -e "source('bin/generate_md_episodes.R')"  
 

--- a/bin/watchRmd.sh
+++ b/bin/watchRmd.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-while inotifywait -e close_write  _episodes_rmd/*.Rmd; do make lesson-md; done
+while fswatch --event=Updated _episodes_rmd/*.Rmd; do make lesson-md; done
 


### PR DESCRIPTION
I have modified the build process so that only the R Markdown files in _episodes_rmd/ that have changed are converted to markdown when running  make lesson-md 

Previously all the episodes were rebuilt if any R markdown files were changed