### PR TITLE
Adds capability to render MultiDay Lessons as MultiPart Lessons

### DIFF
--- a/_includes/syllabus.html
+++ b/_includes/syllabus.html
@@ -1,6 +1,7 @@
 {% comment %}
   Display syllabus in tabular form.
   Days are displayed if at least one episode has 'start = true'.
+  Days are displayed as Parts if at least one episode has 'part = true'.
 {% endcomment %}
 <div class="syllabus">
   <h2 id="schedule">Schedule</h2>
@@ -8,8 +9,12 @@
   {% assign lesson_number = 0 %}
   {% assign day = 0 %}
   {% assign multiday = false %}
+  {% assign partnotday = false %}
   {% for episode in site.episodes %}
     {% if episode.start %}{% assign multiday = true %}{% break %}{% endif %}
+  {% endfor %}
+  {% for episode in site.episodes %}
+    {% if episode.parts %}{% assign partnotday = true %}{% break %}{% endif %}
   {% endfor %}
   {% assign current = site.start_time %}
 
@@ -33,12 +38,14 @@
           <td class="col-md-7"></td>
         </tr>
       {% endif %}
-      {% assign current = site.start_time %} {% comment %}Re-set start time of this episode to general daily start time {% endcomment %}
+      {% if partnotday %}{% else %}
+        {% assign current = site.start_time %} {% comment %}Re-set start time of this episode to general daily start time {% endcomment %}
+      {% endif %}
     {% endif %}
     {% assign hours = current | divided_by: 60 %}
     {% assign minutes = current | modulo: 60 %}
     <tr>
-      {% if multiday %}<td class="col-md-1">{% if episode.start %}Day {{ day }}{% endif %}</td>{% endif %}
+      {% if multiday %}<td class="col-md-1">{% if episode.start %}{% if partnotday %}Part{% else %}Day{% endif %} {{ day }}{% endif %}</td>{% endif %}
       <td class="{% if multiday %}col-md-1{% else %}col-md-2{% endif %}">{% if hours < 10 %}0{% endif %}{{ hours }}:{% if minutes < 10 %}0{% endif %}{{ minutes }}</td>
       <td class="col-md-3">
         {% assign lesson_number = lesson_number | plus: 1 %}


### PR DESCRIPTION
    No change to default rendering of lesson content
    Requires extra site variable "parts" in conjunction with "start"
     to alter rendering.

---

SWC's style template currently allows for MultiDay lessons
to be displayed in the Schedule as follows:

```
 		Setup 			Download files ...
Day 1 	09:00 	1. Introduction 	Key question
	09:30 	2. Second episode 	Key question
	10:00 	3. Third episode 	Key question
	10:30 	Finish 	
Day 2 	09:00 	4. Fourth episode 	Key question
	09:30 	5. Fifth episode 	Key question
	10:00 	Finish
```

In a recent email conversation amongst the Data Carpentry
Cloud Genomics maintainers, I had sugggested that one way
that we might seek to handle the situation whereby our
proto-Lesson was being derived from a number of seperate
existing resources (a number of which duplicated the core
episode themes) within the overall Lesson syllabus being
proposed, would be to make the `gh-pages` branch a MultiDay
Lesson, so that the episodes from the separate resources
could all be displayed, in order, but be separated into
multiple days, until such time as we might refactor the
content.

Thinking that the "Days' approach seemed a little clumsy,
I also had the idea that a temporary change to

`_includes/syllabus.html`

whereby the word "Day" would be replaced by "Part", would
look a little less clumsy, but then started thinking about making 
that change less of a temporary one, but something that
could be a user-effected choice.


This PR takes the idea that some SWC Lessons might benefit
from being laid out in seperate Parts and so adds to the
current styles template, via a small set of changes to

`_includes/syllabus.html`

the capability to make a multiday lesson be rendered as

```
 		Setup 			Download files ...
Part 1	09:00 	1. Introduction 	Key question
	09:00 	2. Second episode 	Key question
	10:00 	3. Third episode 	Key question
	10:30 	Finish 	
Part 2	10:30 	4. Fourth episode 	Key question
	11:00 	5. Fifth episode 	Key question
	11:30 	Finish
```

Note that the the Mutliday's resetting of the start time for each
new day is removed when breaking up a Lesson into Parts.

That does beg the question as to how to handle MultiPart Lessons
held within Multiday Lessons, but that's one for the future!

---
Kevin M. Buckley

eScience Consultant
School of Engineering and Computer Science
Victoria University of Wellington
New Zealand 
