### PR TITLE
links.md: add links to carpentries' lessons overview pages

### DIFF
--- a/_includes/links.md
+++ b/_includes/links.md
@@ -18,8 +18,8 @@
 [jekyll-windows]: http://jekyll-windows.juthilo.com/
 [jekyll]: https://jekyllrb.com/
 [jupyter]: https://jupyter.org/
-[lesson-example]: https://carpentries.github.io/lesson-example/
 [lc-lessons]: https://librarycarpentry.org/#portfolio
+[lesson-example]: https://carpentries.github.io/lesson-example/
 [mit-license]: https://opensource.org/licenses/mit-license.html
 [morea]: https://morea-framework.github.io/
 [numfocus]: https://numfocus.org/
@@ -34,7 +34,7 @@
 [ruby-installer]: https://rubyinstaller.org/
 [rubygems]: https://rubygems.org/pages/download/
 [styles]: https://github.com/carpentries/styles/
-[swc-releases]: https://github.com/swcarpentry/swc-releases
 [swc-lessons]: https://software-carpentry.org/lessons/ 
+[swc-releases]: https://github.com/swcarpentry/swc-releases
 [workshop-repo]: {{ site.workshop_repo }}
 [yaml]: http://yaml.org/

--- a/_includes/links.md
+++ b/_includes/links.md
@@ -9,6 +9,7 @@
 [cran-checkpoint]: https://cran.r-project.org/package=checkpoint
 [cran-knitr]: https://cran.r-project.org/package=knitr
 [cran-stringr]: https://cran.r-project.org/package=stringr
+[dc-lessons]: http://www.datacarpentry.org/lessons/
 [email]: mailto:team@carpentries.org
 [github-importer]: https://import.github.com/
 [importer]: https://github.com/new/import
@@ -18,6 +19,7 @@
 [jekyll]: https://jekyllrb.com/
 [jupyter]: https://jupyter.org/
 [lesson-example]: https://carpentries.github.io/lesson-example/
+[lc-lessons]: https://librarycarpentry.org/#portfolio
 [mit-license]: https://opensource.org/licenses/mit-license.html
 [morea]: https://morea-framework.github.io/
 [numfocus]: https://numfocus.org/
@@ -33,5 +35,6 @@
 [rubygems]: https://rubygems.org/pages/download/
 [styles]: https://github.com/carpentries/styles/
 [swc-releases]: https://github.com/swcarpentry/swc-releases
+[swc-lessons]: https://software-carpentry.org/lessons/ 
 [workshop-repo]: {{ site.workshop_repo }}
 [yaml]: http://yaml.org/


### PR DESCRIPTION
Individual lessons may want to easily link to the various lesson overview pages. This PR bundles those link targets centrally.