### PR TITLE
Only knit rmd files to md if they have changed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,9 +88,8 @@ HTML_DST = \
 ## lesson-md        : convert Rmarkdown files to markdown
 lesson-md : ${RMD_DST}
 
-# Use of .NOTPARALLEL makes rule execute only once
-${RMD_DST} : ${RMD_SRC}
-	@bin/knit_lessons.sh ${RMD_SRC}
+_episodes/%.md: _episodes_rmd/%.Rmd
+	@bin/knit_lessons.sh $< $@
 
 ## lesson-check     : validate lesson Markdown.
 lesson-check : lesson-fixme

--- a/bin/generate_md_episodes.R
+++ b/bin/generate_md_episodes.R
@@ -26,7 +26,7 @@ generate_md_episodes <- function() {
 
     ## get the Rmd file to process from the command line, and generate the path for their respective outputs
     args  <- commandArgs(trailingOnly = TRUE)
-    if (length(args) != 2){
+    if (!identical(length(args), 2L)) {
       stop("input and output file must be passed to the script")
     }
     

--- a/bin/generate_md_episodes.R
+++ b/bin/generate_md_episodes.R
@@ -24,15 +24,18 @@ generate_md_episodes <- function() {
         install.packages(missing_pkgs)
     }
 
-    ## find all the Rmd files, and generate the paths for their respective outputs
-    src_rmd <- list.files(pattern = "??-*.Rmd$", path = "_episodes_rmd", full.names = TRUE)
-    dest_md <- file.path("_episodes", gsub("Rmd$", "md", basename(src_rmd)))
+    ## get the Rmd file to process from the command line, and generate the path for their respective outputs
+    args  <- commandArgs(trailingOnly = TRUE)
+    if (length(args) != 2){
+      stop("input and output file must be passed to the script")
+    }
     
+    src_rmd <- args[1]
+    dest_md <- args[2]
+
     ## knit the Rmd into markdown
-    mapply(function(x, y) {
-        knitr::knit(x, output = y)
-    }, src_rmd, dest_md)
-    
+    knitr::knit(src_rmd, output = dest_md)
+
     # Read the generated md files and add comments advising not to edit them
     vapply(dest_md, function(y) {
       con <- file(y)

--- a/bin/knit_lessons.sh
+++ b/bin/knit_lessons.sh
@@ -4,5 +4,5 @@
 # The Makefile passes in the names of files.
 
 if [ $# -ne 0 ] ; then
-    Rscript -e "source('bin/generate_md_episodes.R')"
+    Rscript -e "source('bin/generate_md_episodes.R')" $*
 fi


### PR DESCRIPTION
This PR is a follow-on of [my comment](https://github.com/carpentries/styles/pull/153#issuecomment-401537578) on #153. The changes make it so that only Rmd files that have been changed are knit to md. They were motivated by the fact that the total time to build all the episodes of https://github.com/datacarpentry/r-raster-vector-geospatial is very long. This makes the existing setup difficult for local interactive development. The workflow would then be to call `make lesson-md` to build only the Rmds that have changed and `make -B lesson-md` to build all Rmds regardless of the `touch` stamp.