### PR TITLE
Fix footer and copyright notice

### DIFF
--- a/_includes/lesson_footer.html
+++ b/_includes/lesson_footer.html
@@ -40,12 +40,9 @@
 	<a href="{{ site.github.repository_url }}/blob/gh-pages/CITATION">Cite</a>
 	/
 	<a href="mailto:{{ site.email }}">Contact</a>
-    </div>
-  </div>
-  <div class="row">
-    <div class="col-md-12" align="center">
-      Using <a href="https://github.com/carpentries/styles/">The Carpentries style</a>
-      version <a href="https://github.com/carpentries/styles/releases/tag/v9.5.2">9.5.2</a>.
+	<br>
+	Using <a href="https://github.com/carpentries/styles/">The Carpentries style</a>
+	version <a href="https://github.com/carpentries/styles/releases/tag/v9.5.2">9.5.2</a>.
     </div>
   </div>
 </footer>

--- a/_includes/lesson_footer.html
+++ b/_includes/lesson_footer.html
@@ -5,22 +5,22 @@
   <div class="row">
     <div class="col-md-6 copyright" align="left">
 	{% if site.carpentry == "swc" %}
-	Copyright &copy; 2018–{{ 'now' | date: "%Y" }}
+	<a href="{{ site.cc_by }}">CC-BY</a>  &copy; 2018–{{ 'now' | date: "%Y" }}
 	<a href="{{ site.carpentries_site }}">The Carpentries</a>
         <br>
-        Copyright &copy; 2016–2018
+        <a href="{{ site.cc_by }}">CC-BY</a>  &copy; 2016–2017
 	<a href="{{ site.swc_site }}">Software Carpentry Foundation</a>
 	{% elsif site.carpentry == "dc" %}
-	Copyright &copy; 2018–{{ 'now' | date: "%Y" }}
+	<a href="{{ site.cc_by }}">CC-BY</a>  &copy; 2018–{{ 'now' | date: "%Y" }}
 	<a href="{{ site.carpentries_site }}">The Carpentries</a>
         <br>
-        Copyright &copy; 2016–2018
+        <a href="{{ site.cc_by }}">CC-BY</a>  &copy; 2016–2018
 	<a href="{{ site.dc_site }}">Data Carpentry</a>
 	{% elsif site.carpentry == "lc" %}
-	Copyright &copy; 2016–{{ 'now' | date: "%Y" }}
+	<a href="{{ site.cc_by }}">CC-BY</a>  &copy; 2016–{{ 'now' | date: "%Y" }}
 	<a href="{{ site.lc_site }}">Library Carpentry</a>
 	{% elsif site.carpentry == "cp" %}
-	Copyright &copy; 2018–{{ 'now' | date: "%Y" }}
+	<a href="{{ site.cc_by }}">CC-BY</a>  &copy; 2018–{{ 'now' | date: "%Y" }}
 	<a href="{{ site.carpentries_site }}">The Carpentries</a>
 	{% endif %}
     </div>

--- a/assets/css/lesson.scss
+++ b/assets/css/lesson.scss
@@ -156,7 +156,6 @@ img {
 footer .copyright,
 footer .help-links
 {
-    font-size: 18px;
     margin-top: 10px;
     margin-bottom: 10px;
     font-weight: 500;

--- a/bin/boilerplate/_config.yml
+++ b/bin/boilerplate/_config.yml
@@ -43,6 +43,7 @@ template_repo: "https://github.com/carpentries/styles"
 training_site: "https://carpentries.github.io/instructor-training"
 workshop_repo: "https://github.com/carpentries/workshop-template"
 workshop_site: "https://carpentries.github.io/workshop-template"
+cc_by: "https://creativecommons.org/licenses/by/4.0/"
 
 # Surveys.
 pre_survey: "https://www.surveymonkey.com/r/swc_pre_workshop_v1?workshop_id="


### PR DESCRIPTION
Make footer a little tidier, and replace the word "Copyright" with "CC-BY"

Before:
![screenshot from 2018-07-03 17-11-01](https://user-images.githubusercontent.com/5502922/42244770-484494fa-7ee4-11e8-937a-1a5c231cc5a6.png)

After:
![screenshot from 2018-07-03 17-11-15](https://user-images.githubusercontent.com/5502922/42244776-4c25489e-7ee4-11e8-874f-c2587e0f2079.png)
