### PR TITLE
space out callout elements better

### DIFF
--- a/assets/css/lesson.scss
+++ b/assets/css/lesson.scss
@@ -29,10 +29,10 @@ $color-testimonial: #fc8dc1 !default;
 //----------------------------------------
 
 @mixin cdSetup($color) {
-  color: $color;
-  border-left: solid 5px $color;
-  margin-bottom: 0px;
-  border-radius: 4px 0 0 4px;
+    color: $color;
+    border-left: solid 5px $color;
+    margin: 15px;
+    border-radius: 4px 0 0 4px;
 }
 
 .error  { @include cdSetup($color-error); }
@@ -81,7 +81,10 @@ $codeblock-padding: 5px !default;
   padding-right: 0;
   border: 1px solid;
   border-color: $color;
+  border-radius: 4px;
   padding-bottom: $codeblock-padding;
+
+  margin: 15px;
 
   h2 {
     padding-top: $codeblock-padding;
@@ -124,6 +127,10 @@ $codeblock-padding: 5px !default;
 .solution h3,
 .testimonial h3 {
 font-size: 18px;
+}
+
+blockquote p {
+    margin: 5px;
 }
 
 //----------------------------------------


### PR DESCRIPTION
I find the different parts of the content of the callout boxes crowded. Attempting to give them a little more room.

Before:

![screenshot from 2018-07-03 17-48-14](https://user-images.githubusercontent.com/5502922/42246092-4be58da8-7ee9-11e8-8f37-ccf2143e1750.png)

After:
![screenshot from 2018-07-03 17-46-36](https://user-images.githubusercontent.com/5502922/42246100-52934bae-7ee9-11e8-945b-7872a357eb18.png)
