### PR TITLE
Adjust H2 and H3 headers

### DIFF
--- a/assets/css/lesson.scss
+++ b/assets/css/lesson.scss
@@ -141,6 +141,15 @@ img {
   max-width: 100%;
 }
 
+article h2 {
+  margin: 48px 0 16px;
+  border-bottom: solid 1px #eaecef;
+  padding-bottom: 0.3em;
+  line-height: 1.25;
+}
+
+article h3 { margin: 40px 0 16px; }
+
 //----------------------------------------
 // Miscellaneous.
 //----------------------------------------


### PR DESCRIPTION
Suggestion to improve vertical margins for headers. Also, adds a gray horizontal line under H2 headers.

<img width="840" alt="headers copy" src="https://user-images.githubusercontent.com/13123663/42335918-75f6072e-8071-11e8-9e4c-70fa41984b8b.png">
