### PR TITLE
figures.md: fixes and improvements

### DIFF
--- a/assets/css/lesson.scss
+++ b/assets/css/lesson.scss
@@ -156,7 +156,6 @@ article img {
 
 .figures h2 { margin-top: 100px; }
 .figures h3 { margin-top: 20px; }
-.figures img { display: block; margin: 20px auto; }
 
 .maintitle {
   text-align: center;

--- a/assets/css/lesson.scss
+++ b/assets/css/lesson.scss
@@ -155,7 +155,6 @@ article img {
 //----------------------------------------
 
 .figures h2 { margin-top: 100px; }
-.figures h3 { margin-top: 20px; }
 
 .maintitle {
   text-align: center;

--- a/assets/css/lesson.scss
+++ b/assets/css/lesson.scss
@@ -154,6 +154,10 @@ article img {
 // Miscellaneous.
 //----------------------------------------
 
+.figures h2 { margin-top: 100px; }
+.figures h3 { margin-top: 20px; }
+.figures img { display: block; margin: 20px auto; }
+
 .maintitle {
   text-align: center;
 }

--- a/bin/boilerplate/_extras/figures.md
+++ b/bin/boilerplate/_extras/figures.md
@@ -28,7 +28,7 @@ title: Figures
             var h1text = htmlDocArticle.getElementsByTagName("h1")[0].innerHTML;
 
             var htitle = document.createElement('h2');
-            htitle.innerHTML = 'Episode "' + h1text + '"';
+            htitle.innerHTML = h1text;
             article_here.appendChild(htitle);
 
             var image_num = 0;

--- a/bin/boilerplate/_extras/figures.md
+++ b/bin/boilerplate/_extras/figures.md
@@ -69,3 +69,5 @@ Create anchor for each one of the episodes.
 {% for episode in site.episodes %}
 <article id="{{ episode.url }}"></article>
 {% endfor %}
+
+{% include links.md %}

--- a/bin/boilerplate/_extras/figures.md
+++ b/bin/boilerplate/_extras/figures.md
@@ -29,7 +29,6 @@ title: Figures
 
             var htitle = document.createElement('h2');
             htitle.innerHTML = 'Episode "' + h1text + '"';
-            htitle.style = "margin-top: 100px;";
             article_here.appendChild(htitle);
 
             var hr = document.createElement('hr');
@@ -41,12 +40,10 @@ title: Figures
 
               var title = document.createElement('h3');
               title.innerHTML = "Figure " + image_num + ". " + image.alt;
-              title.style = "margin-top: 20px;"
               article_here.appendChild(title);
 
               var img = document.createElement('img');
               img.src = image.src;
-              img.style = "display: block; margin: 20px auto;"
               article_here.appendChild(img);
 
               if (image_num < images.length) {
@@ -67,7 +64,7 @@ title: Figures
 Create anchor for each one of the episodes.
 {% endcomment %}
 {% for episode in site.episodes %}
-<article id="{{ episode.url }}"></article>
+<article id="{{ episode.url }}" class="figures"></article>
 {% endfor %}
 
 {% include links.md %}

--- a/bin/boilerplate/_extras/figures.md
+++ b/bin/boilerplate/_extras/figures.md
@@ -35,8 +35,8 @@ title: Figures
             for (let image of images) {
               image_num++;
 
-              var title = document.createElement('h3');
-              title.innerHTML = "Figure " + image_num + ". " + image.alt;
+              var title = document.createElement('p');
+              title.innerHTML = "<strong>Figure " + image_num + ".</strong> " + image.alt;
               article_here.appendChild(title);
 
               var img = document.createElement('img');

--- a/bin/boilerplate/_extras/figures.md
+++ b/bin/boilerplate/_extras/figures.md
@@ -31,9 +31,6 @@ title: Figures
             htitle.innerHTML = 'Episode "' + h1text + '"';
             article_here.appendChild(htitle);
 
-            var hr = document.createElement('hr');
-            article_here.appendChild(hr);
-
             var image_num = 0;
             for (let image of images) {
               image_num++;

--- a/bin/boilerplate/_extras/figures.md
+++ b/bin/boilerplate/_extras/figures.md
@@ -5,22 +5,55 @@ title: Figures
   window.onload = function() {
     var lesson_episodes = [
     {% for episode in site.episodes %}
-    "{{ episode.url}}"{% unless forloop.last %},{% endunless %}
+    "{{ episode.url }}"{% unless forloop.last %},{% endunless %}
     {% endfor %}
     ];
+
     var xmlHttp = [];  /* Required since we are going to query every episode. */
     for (i=0; i < lesson_episodes.length; i++) {
+
       xmlHttp[i] = new XMLHttpRequest();
       xmlHttp[i].episode = lesson_episodes[i];  /* To enable use this later. */
       xmlHttp[i].onreadystatechange = function() {
+
         if (this.readyState == 4 && this.status == 200) {
-          var article_here = document.getElementById(this.episode);
           var parser = new DOMParser();
           var htmlDoc = parser.parseFromString(this.responseText,"text/html");
           var htmlDocArticle = htmlDoc.getElementsByTagName("article")[0];
-          article_here.appendChild(htmlDocArticle.getElementsByTagName("h1")[0]);
-          for (let image of htmlDocArticle.getElementsByTagName("img")) {
-            article_here.appendChild(image);
+
+          var article_here = document.getElementById(this.episode);
+          var images = htmlDocArticle.getElementsByTagName("img");
+
+          if (images.length > 0) {
+            var h1text = htmlDocArticle.getElementsByTagName("h1")[0].innerHTML;
+
+            var htitle = document.createElement('h2');
+            htitle.innerHTML = 'Episode "' + h1text + '"';
+            htitle.style = "margin-top: 100px;";
+            article_here.appendChild(htitle);
+
+            var hr = document.createElement('hr');
+            article_here.appendChild(hr);
+
+            var image_num = 0;
+            for (let image of images) {
+              image_num++;
+
+              var title = document.createElement('h3');
+              title.innerHTML = "Figure " + image_num + ". " + image.alt;
+              title.style = "margin-top: 20px;"
+              article_here.appendChild(title);
+
+              var img = document.createElement('img');
+              img.src = image.src;
+              img.style = "display: block; margin: 20px auto;"
+              article_here.appendChild(img);
+
+              if (image_num < images.length) {
+                var hr = document.createElement('hr');
+                article_here.appendChild(hr);
+              }
+            }
           }
         }
       }
@@ -36,5 +69,3 @@ Create anchor for each one of the episodes.
 {% for episode in site.episodes %}
 <article id="{{ episode.url }}"></article>
 {% endfor %}
-
-{% include links.md %}


### PR DESCRIPTION
1. Fix the script so that all figures are displayed.
2. Add image numbers.
3. Don't add headers for episodes without images.
4. Add horizontal rulers to better separate adjacent images.
   Don't add a ruler after the last image in the episode.
5. Add empty lines to improve code readability.

I'll add before and after screenshots later.