### PR TITLE
Code/callout/prereq/etc blocks: set left and right margins to 0

### DIFF
--- a/assets/css/lesson.scss
+++ b/assets/css/lesson.scss
@@ -31,7 +31,7 @@ $color-testimonial: #fc8dc1 !default;
 @mixin cdSetup($color) {
     color: $color;
     border-left: solid 5px $color;
-    margin: 15px;
+    margin: 15px 0;
     border-radius: 4px 0 0 4px;
 }
 
@@ -84,7 +84,7 @@ $codeblock-padding: 5px !default;
   border-radius: 4px;
   padding-bottom: $codeblock-padding;
 
-  margin: 15px;
+  margin: 15px 0;
 
   h2 {
     padding-top: $codeblock-padding;


### PR DESCRIPTION
Setting `margin: 15px` causes all blocks (Prereq, code, etc) to be misaligned with the main text. 
This PR sets the left and right margins to 0.

Related commit: 80d6638a