### PR TITLE
Clone images instead of creating new ones

### DIFF
--- a/bin/boilerplate/_extras/figures.md
+++ b/bin/boilerplate/_extras/figures.md
@@ -39,9 +39,7 @@ title: Figures
               title.innerHTML = "<strong>Figure " + image_num + ".</strong> " + image.alt;
               article_here.appendChild(title);
 
-              var img = document.createElement('img');
-              img.src = image.src;
-              article_here.appendChild(img);
+              article_here.appendChild(image.cloneNode(false));
 
               if (image_num < images.length) {
                 var hr = document.createElement('hr');


### PR DESCRIPTION
Clone images instead of creating new document elements.

No visual changes are expected.

Should have a benefit of cloning alt.text / title, if any