### PR TITLE
Remove gh-variables from links.md

### DIFF
--- a/_includes/links.md
+++ b/_includes/links.md
@@ -1,5 +1,3 @@
-{% include gh_variables.html %}
-
 [cc-by-human]: https://creativecommons.org/licenses/by/4.0/
 [cc-by-legal]: https://creativecommons.org/licenses/by/4.0/legalcode
 [ci]: http://communityin.org/
@@ -36,7 +34,7 @@
 [ruby-installer]: https://rubyinstaller.org/
 [rubygems]: https://rubygems.org/pages/download/
 [styles]: https://github.com/carpentries/styles/
-[swc-lessons]: https://software-carpentry.org/lessons/ 
+[swc-lessons]: https://software-carpentry.org/lessons/
 [swc-releases]: https://github.com/swcarpentry/swc-releases
 [workshop-repo]: {{ site.workshop_repo }}
 [yaml]: http://yaml.org/


### PR DESCRIPTION
See description in carpentries/styles#356

This blocks execution of `make lesson-check`, so I'm marking this as high priority.