### PR TITLE
CONTRIBUTING.md: remove repetitive text

### DIFF
--- a/bin/boilerplate/CONTRIBUTING.md
+++ b/bin/boilerplate/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-[The Carpentries][c-site]([Software Carpentry][swc-site], [Data Carpentry][dc-site], and [Library Carpentry][lc-site]) are open source projects,
+[The Carpentries][c-site] ([Software Carpentry][swc-site], [Data Carpentry][dc-site], and [Library Carpentry][lc-site]) are open source projects,
 and we welcome contributions of all kinds:
 new lessons,
 fixes to existing material,
@@ -14,7 +14,7 @@ you agree that we may redistribute your work under [our license](LICENSE.md).
 In exchange,
 we will address your issues and/or assess your change proposal as promptly as we can,
 and help you become a member of our community.
-Everyone involved in [The Carpentries][c-site]([Software Carpentry][swc-site], [Data Carpentry][dc-site], and [Library Carpentry][lc-site]) 
+Everyone involved in [The Carpentries][c-site]
 agrees to abide by our [code of conduct](CODE_OF_CONDUCT.md).
 
 ## How to Contribute
@@ -149,4 +149,3 @@ You can also [reach us by email][email].
 [c-site]: https://carpentries.org/
 [lc-site]: https://librarycarpentry.org/
 [lc-issues]: https://github.com/issues?q=user%3Alibrarycarpentry
-


### PR DESCRIPTION
Remove repetitive text, add a white-space before parentheses in `The Carpentries(Software Carpentry, Data Carpentry, and Library Carpentry)`