### PR TITLE
knit_lessons.sh: require 2 inputs exactly

### DIFF
--- a/bin/knit_lessons.sh
+++ b/bin/knit_lessons.sh
@@ -3,6 +3,6 @@
 # Only try running R to translate files if there are some files present.
 # The Makefile passes in the names of files.
 
-if [ $# -ne 0 ] ; then
+if [ $# -eq 2 ] ; then
     Rscript -e "source('bin/generate_md_episodes.R')" "$@"
 fi


### PR DESCRIPTION
I believe `generate_md_episodes.R` requires 2 inputs exactly...
ping @fmichonneau 