### PR TITLE
Removed _config.yml from required *markdown* files

### DIFF
--- a/bin/lesson_check.py
+++ b/bin/lesson_check.py
@@ -35,7 +35,6 @@ REQUIRED_FILES = {
     '%/README.md': False,
     '%/_extras/discuss.md': True,
     '%/_extras/guide.md': True,
-    '%/_config.yml': True,
     '%/index.md': True,
     '%/reference.md': True,
     '%/setup.md': True,


### PR DESCRIPTION
Reverting cb4e1dd which broke lesson_check.py by requiring _config.yml to be present in a list of files that was built by pattern matching on *.md

Please delete this line and the text below before submitting your contribution.

---

Thanks for contributing! If this contribution is for instructor training, please send an email to checkout@carpentries.org with a link to this contribution so we can record your progress. You’ve completed your contribution step for instructor checkout just by submitting this contribution.  

Please keep in mind that lesson maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum.  If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact Kate Hertweck (k8hertweck@gmail.com).  

---
