### PR TITLE
Colorize all boxes

### DIFF
--- a/assets/css/lesson.scss
+++ b/assets/css/lesson.scss
@@ -129,6 +129,17 @@ $codeblock-padding: 5px !default;
 font-size: 18px;
 }
 
+.challenge    { background-color: #eec27520; }
+.callout      { background-color: #f4fd9c20; }
+.challenge    { background-color: #eec27520; }
+.checklist    { background-color: #dfd2a020; }
+.discussion   { background-color: #eec27520; }
+.keypoints    { background-color: #7ae78e20; }
+.objectives   { background-color: #daee8420; }
+.prereq       { background-color: #9cd6dc20; }
+.solution     { background-color: #ded4b94d; }
+.testimonial  { background-color: #fc8dc120; }
+
 blockquote p {
     margin: 5px;
 }


### PR DESCRIPTION
Use the same colors but apply 12.5% opacity.
Solution boxes use 30% opacity

<img width="709" alt="image" src="https://user-images.githubusercontent.com/13123663/53660070-f103fa80-3c54-11e9-9eca-37b40bc35673.png">

<img width="709" alt="image" src="https://user-images.githubusercontent.com/13123663/53660100-fe20e980-3c54-11e9-8c5a-7ee36f47afd6.png">

<img width="709" alt="image" src="https://user-images.githubusercontent.com/13123663/53660132-0da03280-3c55-11e9-98e2-33d9d82fa0cf.png">

<img width="709" alt="image" src="https://user-images.githubusercontent.com/13123663/53660158-1db81200-3c55-11e9-98a6-e7791428be0b.png">

<img width="709" alt="image" src="https://user-images.githubusercontent.com/13123663/53660180-27da1080-3c55-11e9-8ffc-0acc5828afbd.png">
