### PR TITLE
Improve contrast of code elements

### DIFF
--- a/assets/css/lesson.scss
+++ b/assets/css/lesson.scss
@@ -151,7 +151,7 @@ blockquote p {
 code {
   white-space: nowrap;
   padding: 2px 5px;
-  color: #3d90d9;
+  color: #006cad;
   background-color: #e7e7e7;
 }
 


### PR DESCRIPTION
Tool called `tota11y` that @raynamharris mentioned in carpentries/styles#390 reports that contrast of our code elements is very low. This PR fixes this using the suggestion from that tool. Here, I'm not changing the gray background but rather darken the blue color used to display text.

### Before
<img width="953" alt="image" src="https://user-images.githubusercontent.com/13123663/53909954-633f5b00-4018-11e9-8600-39df0d79a352.png">

### After

<img width="953" alt="image" src="https://user-images.githubusercontent.com/13123663/53909876-3d19bb00-4018-11e9-97ec-730605f969aa.png">
