### PR TITLE
Prefix code blocks with language names

### DIFF
--- a/assets/css/bootstrap.css
+++ b/assets/css/bootstrap.css
@@ -1562,15 +1562,14 @@ kbd kbd {
 pre {
   display: block;
   padding: 9.5px;
-  margin: 0 0 10px;
+  margin: 0;
   font-size: 13px;
   line-height: 1.42857143;
   color: inherit; /* #333; -- CHANGE -- */
   word-break: break-all;
   word-wrap: break-word;
   background-color: #f5f5f5;
-  border: 1px solid #ccc;
-  border-radius: 4px;
+  border: none;
 }
 pre code {
   padding: 0;

--- a/assets/css/lesson.scss
+++ b/assets/css/lesson.scss
@@ -30,8 +30,9 @@ $color-testimonial: #fc8dc1 !default;
 
 @mixin cdSetup($color) {
     color: $color;
+    border: solid 0.5px $color;
     border-left: solid 5px $color;
-    margin: 15px 0;
+    margin: 15px 5px 10px 0;
     border-radius: 4px 0 0 4px;
 }
 
@@ -46,23 +47,31 @@ $color-testimonial: #fc8dc1 !default;
 .r, .language-r           { @include cdSetup($color-source); }
 .sql, .language-sql       { @include cdSetup($color-source); }
 
-.error pre,
-.output pre,
-.source pre,
-.bash pre,
-.language-bash pre,
-.make pre,
-.language-make pre,
-.matlab pre,
-.language-matlab pre,
-.python pre,
-.language-python pre,
-.r pre,
-.language-r pre,
-.sql pre ,
-.language-sql pre {
-  border-radius: 0 4px 4px 0;
+.error::before,
+.output::before,
+.source::before,
+.bash::before, .language-bash::before,
+.make::before, .language-make::before,
+.matlab::before, .language-matlab::before,
+.python::before, .language-python::before,
+.r::before, .language-r::before,
+.sql::before, .language-sql::before {
+  background-color: #f2eff6;
+  display: block;
+  font-weight: bold;
+  padding: 5px 10px;
 }
+
+.error::before  { background-color: #ffebe6; content: "Error"; }
+.output::before { background-color: #efefef; content: "Output"; }
+.source::before { content: "Code"; }
+.bash::before, .language-bash::before { content: "Bash"; }
+.make::before, .language-make::before { content: "Make"; }
+.matlab::before, .language-matlab::before { content: "Matlab"; }
+.python::before, .language-python::before { content: "Python"; }
+.r::before, .language-r::before { content: "R"; }
+.sql::before, .language-sql::before { content: "SQL"; }
+
 
 //----------------------------------------
 // Specialized blockquote environments for learning objectives, callouts, etc.
@@ -75,16 +84,12 @@ $codeblock-padding: 5px !default;
   $gradientcolor1: $color;
   $gradientcolor2: scale-color($color, $lightness: 10%);
 
-  padding-left: $codeblock-padding;
-  padding-top: 0;
-  padding-bottom: 0;
-  padding-right: 0;
+  padding: 0 0 $codeblock-padding $codeblock-padding;
   border: 1px solid;
   border-color: $color;
   border-radius: 4px;
-  padding-bottom: $codeblock-padding;
 
-  margin: 15px 0;
+  margin: 15px 5px 10px 0;
 
   h2 {
     padding-top: $codeblock-padding;

--- a/assets/css/syntax.css
+++ b/assets/css/syntax.css
@@ -1,15 +1,15 @@
 .highlight .hll { background-color: #ffffcc }
 .highlight  { background: #f8f8f8; }
-.highlight .c { color: #408080; font-style: italic } /* Comment */
+.highlight .c { color: #387d7d; font-style: italic } /* Comment */
 .highlight .err { border: 1px solid #FF0000 } /* Error */
 .highlight .k { color: #008000; font-weight: bold } /* Keyword */
 .highlight .o { color: #666666 } /* Operator */
-.highlight .ch { color: #408080; font-style: italic } /* Comment.Hashbang */
-.highlight .cm { color: #408080; font-style: italic } /* Comment.Multiline */
+.highlight .ch { color: #387d7d; font-style: italic } /* Comment.Hashbang */
+.highlight .cm { color: #387d7d; font-style: italic } /* Comment.Multiline */
 .highlight .cp { color: #BC7A00 } /* Comment.Preproc */
-.highlight .cpf { color: #408080; font-style: italic } /* Comment.PreprocFile */
-.highlight .c1 { color: #408080; font-style: italic } /* Comment.Single */
-.highlight .cs { color: #408080; font-style: italic } /* Comment.Special */
+.highlight .cpf { color: #387d7d; font-style: italic } /* Comment.PreprocFile */
+.highlight .c1 { color: #387d7d; font-style: italic } /* Comment.Single */
+.highlight .cs { color: #387d7d; font-style: italic } /* Comment.Special */
 .highlight .gd { color: #A00000 } /* Generic.Deleted */
 .highlight .ge { font-style: italic } /* Generic.Emph */
 .highlight .gr { color: #FF0000 } /* Generic.Error */


### PR DESCRIPTION
## Regular code block (undefined and R)
<img width="657" alt="image" src="https://user-images.githubusercontent.com/13123663/54151342-9b73de80-4408-11e9-9bf7-59c6865c211e.png">

<img width="657" alt="image" src="https://user-images.githubusercontent.com/13123663/54151858-c7dc2a80-4409-11e9-8a3e-7beecbad1dc5.png">


## Code block + Output
<img width="657" alt="image" src="https://user-images.githubusercontent.com/13123663/54151469-e261d400-4408-11e9-951b-9afb1280c347.png">

## Code block + Error message
<img width="657" alt="image" src="https://user-images.githubusercontent.com/13123663/54151429-c9f1b980-4408-11e9-8c5c-52692cb663e9.png">

## Code block in a callout box
<img width="657" alt="image" src="https://user-images.githubusercontent.com/13123663/54151545-0e7d5500-4409-11e9-9179-bab7a90ae7ee.png">

## Code and output block in a solution box
<img width="657" alt="image" src="https://user-images.githubusercontent.com/13123663/54151622-3ff62080-4409-11e9-8888-a47d0d8bd8e1.png">
