### PR TITLE
Fix contrast of links in challenge blocks

### DIFF
--- a/assets/css/bootstrap.css
+++ b/assets/css/bootstrap.css
@@ -1098,7 +1098,7 @@ textarea {
   line-height: inherit;
 }
 a {
-  color: #337ab7;
+  color: #2876b5;
   text-decoration: none;
 }
 a:hover,


### PR DESCRIPTION
Tota11y reports that links in our challenge blocks have a
contrast ratio of 4.29, which is lower than their minimum
of 4.5. This PR implements the suggestion that their tool
provides by changing the color or links from #337ab7 to #2876b5.