### PR TITLE
reference to the webpage of the lesson + goodfirst

### DIFF
--- a/bin/boilerplate/README.md
+++ b/bin/boilerplate/README.md
@@ -2,7 +2,7 @@
 
 [![Create a Slack Account with us](https://img.shields.io/badge/Create_Slack_Account-The_Carpentries-071159.svg)](https://swc-slack-invite.herokuapp.com/)
 
-FIXME
+This repository generates the corresponding lesson website from [The Carpentries](https://carpentries.org/) repertoire of lessons. 
 
 ## Contributing
 
@@ -13,9 +13,21 @@ We'd like to ask you to familiarize yourself with our [Contribution Guide](CONTR
 the [more detailed guidelines][lesson-example] on proper formatting, ways to render the lesson locally, and even
 how to write new episodes.
 
+Please see the current list of [issues][] for ideas for contributing to this
+repository. For making your contribution, we use the GitHub flow, which is
+nicely explained in the chapter [Contributing to a Project](http://git-scm.com/book/en/v2/GitHub-Contributing-to-a-Project) in Pro Git
+by Scott Chacon.
+Look for the tag ![good_first_issue](https://img.shields.io/badge/-good%20first%20issue-yellowgreen.svg). This indicates that the mantainers will welcome a pull request fixing this issue.  
+
+
 ## Maintainer(s)
 
-* FIXME
+Current maintainers of this lesson are 
+
+* 
+*
+* 
+
 
 ## Authors
 

--- a/bin/boilerplate/README.md
+++ b/bin/boilerplate/README.md
@@ -17,7 +17,7 @@ Please see the current list of [issues][] for ideas for contributing to this
 repository. For making your contribution, we use the GitHub flow, which is
 nicely explained in the chapter [Contributing to a Project](http://git-scm.com/book/en/v2/GitHub-Contributing-to-a-Project) in Pro Git
 by Scott Chacon.
-Look for the tag ![good_first_issue](https://img.shields.io/badge/-good%20first%20issue-yellowgreen.svg). This indicates that the mantainers will welcome a pull request fixing this issue.  
+Look for the tag ![good_first_issue](https://img.shields.io/badge/-good%20first%20issue-gold.svg). This indicates that the mantainers will welcome a pull request fixing this issue.  
 
 
 ## Maintainer(s)

--- a/bin/boilerplate/README.md
+++ b/bin/boilerplate/README.md
@@ -13,7 +13,7 @@ We'd like to ask you to familiarize yourself with our [Contribution Guide](CONTR
 the [more detailed guidelines][lesson-example] on proper formatting, ways to render the lesson locally, and even
 how to write new episodes.
 
-Please see the current list of [issues][] for ideas for contributing to this
+Please see the current list of [issues][FIXME] for ideas for contributing to this
 repository. For making your contribution, we use the GitHub flow, which is
 nicely explained in the chapter [Contributing to a Project](http://git-scm.com/book/en/v2/GitHub-Contributing-to-a-Project) in Pro Git
 by Scott Chacon.
@@ -24,9 +24,9 @@ Look for the tag ![good_first_issue](https://img.shields.io/badge/-good%20first%
 
 Current maintainers of this lesson are 
 
-* 
-*
-* 
+* FIXME
+* FIXME
+* FIXME
 
 
 ## Authors


### PR DESCRIPTION
This contribution adds reference to the web page of the lesson in the Carpentries and makes it easier for visitors who want to contribute to get familiar with the good first issue badge.
This adds a list of current maintainers to the README.md, as well.

This is inspired by the README of the https://github.com/swcarpentry/r-novice-inflammation
and tries to solve the
issues:
https://github.com/swcarpentry/r-novice-inflammation/issues/401
and
https://github.com/datacarpentry/R-ecology-lesson/issues/491

I accept contributions to improve this PR.
