### PR TITLE
make title show episode title first

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -25,7 +25,12 @@
 	<script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
 	<script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
 	<![endif]-->
-    <title>{{ site.title }}{% if page.title %}: {{ page.title }}{% endif %}</title>
+
+  <title>
+  {% if page.title %}{{ page.title }}: {% endif %}
+  {% if site.title %}{{ site.title }}{% endif %}
+  </title>  
+
   </head>
   <body>
 


### PR DESCRIPTION
By showing the episode title first, we can easily see what episode names when we have multiple tabs open.  For example:

**Before:**
![image](https://user-images.githubusercontent.com/829690/57308660-c3a05680-70b4-11e9-9c2d-f969601bcda5.png)

**After:**
![image](https://user-images.githubusercontent.com/829690/57308705-d1ee7280-70b4-11e9-85b5-a7a1c4e20dc0.png)
