### PR TITLE
links.md: fix lesson-setup link

### DIFF
--- a/_includes/links.md
+++ b/_includes/links.md
@@ -1,3 +1,4 @@
+{% include base_path.html %}
 [cc-by-human]: https://creativecommons.org/licenses/by/4.0/
 [cc-by-legal]: https://creativecommons.org/licenses/by/4.0/legalcode
 [ci]: http://communityin.org/

--- a/_includes/links.md
+++ b/_includes/links.md
@@ -26,7 +26,7 @@
 [lesson-license]: {{ relative_root_path }}{% link LICENSE.md %}
 [lesson-mainpage]: {{ relative_root_path }}{% link index.md %}
 [lesson-reference]: {{ relative_root_path }}{% link reference.md %}
-[lesson-setup]: {{ relative_page_root }}{% link setup.md %}
+[lesson-setup]: {{ relative_root_path }}{% link setup.md %}
 [mit-license]: https://opensource.org/licenses/mit-license.html
 [morea]: https://morea-framework.github.io/
 [numfocus]: https://numfocus.org/


### PR DESCRIPTION
Change `relative_page_root` to `relative_root_path`.
I'm not sure why I used `relative_page_root` instead of `relative_root_path` for lesson-setup... copy/paste typo?