### PR TITLE
lesson-check: exclude aio.md, fix read_references

### DIFF
--- a/bin/lesson_check.py
+++ b/bin/lesson_check.py
@@ -55,6 +55,9 @@ P_INTERNAL_LINK_REF = re.compile(r'\[([^\]]+)\]\[([^\]]+)\]')
 # Pattern to match reference links (to resolve internally-defined references).
 P_INTERNAL_LINK_DEF = re.compile(r'^\[([^\]]+)\]:\s*(.+)')
 
+# Pattern to match {% include ... %} statements
+P_INTERNAL_INCLUDE_LINK = re.compile(r'^{% include ([^ ]*) %}$')
+
 # What kinds of blockquotes are allowed?
 KNOWN_BLOCKQUOTES = {
     'callout',
@@ -208,29 +211,44 @@ def read_references(reporter, ref_path):
     {symbolic_name : URL}
     """
 
+    if not ref_path:
+        raise Warning("No filename has been provided.")
+
     result = {}
     urls_seen = set()
-    if ref_path:
-        with open(ref_path, 'r') as reader:
-            for (num, line) in enumerate(reader):
-                line_num = num + 1
-                m = P_INTERNAL_LINK_DEF.search(line)
-                require(m,
-                        '{0}:{1} not valid reference:\n{2}'.format(ref_path, line_num, line.rstrip()))
-                name = m.group(1)
-                url = m.group(2)
-                require(name,
-                        'Empty reference at {0}:{1}'.format(ref_path, line_num))
-                reporter.check(name not in result,
-                               ref_path,
-                               'Duplicate reference {0} at line {1}',
-                               name, line_num)
-                reporter.check(url not in urls_seen,
-                               ref_path,
-                               'Duplicate definition of URL {0} at line {1}',
-                               url, line_num)
-                result[name] = url
-                urls_seen.add(url)
+
+    with open(ref_path, 'r') as reader:
+        for (num, line) in enumerate(reader, 1):
+
+            if P_INTERNAL_INCLUDE_LINK.search(line): continue
+
+            m = P_INTERNAL_LINK_DEF.search(line)
+
+            message = '{}: {} not a valid reference: {}'
+            require(m, message.format(ref_path, num, line.rstrip()))
+
+            name = m.group(1)
+            url = m.group(2)
+
+            message = 'Empty reference at {0}:{1}'
+            require(name, message.format(ref_path, num))
+
+            unique_name = name not in result
+            unique_url = url not in urls_seen
+
+            reporter.check(unique_name,
+                           ref_path,
+                           'Duplicate reference name {0} at line {1}',
+                           name, num)
+
+            reporter.check(unique_url,
+                           ref_path,
+                           'Duplicate definition of URL {0} at line {1}',
+                           url, num)
+
+            result[name] = url
+            urls_seen.add(url)
+
     return result
 
 
@@ -539,7 +557,6 @@ CHECKERS = [
     (re.compile(r'index\.md'), CheckIndex),
     (re.compile(r'reference\.md'), CheckReference),
     (re.compile(r'_episodes/.*\.md'), CheckEpisode),
-    (re.compile(r'aio\.md'), CheckNonJekyll),
     (re.compile(r'.*\.md'), CheckGeneric)
 ]
 


### PR DESCRIPTION
- Don't check metadata in `aio.md` (it no longer has to be empty due to
recent changes).
- Make `read_references` skip `{% include ... %}` lines