### PR TITLE
Use darker purple for code blocks

### DIFF
--- a/assets/css/lesson.scss
+++ b/assets/css/lesson.scss
@@ -11,7 +11,7 @@ $color-brand:       #2b3990 !default;
 // code boxes
 $color-error:       #bd2c00 !default;
 $color-output:      #303030 !default;
-$color-source:      #6e5494 !default;
+$color-source:      #360084 !default;
 
 // blockquotes
 $color-callout:     #f4fd9c !default;


### PR DESCRIPTION
Resolves carpentries/styles#411
Resolves swcarpentry/r-novice-gapminder#522