### PR TITLE
Callout (and other) blocks: proper font size, margins

### DIFF
--- a/assets/css/bootstrap.css
+++ b/assets/css/bootstrap.css
@@ -1476,7 +1476,7 @@ abbr[data-original-title] {
 blockquote {
   padding: 10px 20px;
   margin: 0 0 20px;
-  font-size: 17.5px;
+  font-size: inherit;
   border-left: 5px solid #eeeeee;
 }
 blockquote p:last-child,
@@ -1608,8 +1608,8 @@ pre code {
   margin-left: auto;
 }
 .row {
-  margin-right: -15px;
-  margin-left: -15px;
+  margin-right: -10px;
+  margin-left: -10px;
 }
 .row-no-gutters {
   margin-right: 0;


### PR DESCRIPTION
1. Font size in callout (and other) blocks was recently changed to 17.5px which appears to look strange. In this pull request we inherit font size (from the parent)
2. Margins in keypoint boxes are -15px, resulting in slightly different offset from the left side when compared to the code blocks. By setting margin to -10px, we make offsets in keypoint boxes and code blocks identical.