### PR TITLE
Ignore Jekyll 4's cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .DS_Store
 .ipynb_checkpoints
 .sass-cache
+.jekyll-cache/
 __pycache__
 _site
 .Rproj.user


### PR DESCRIPTION
See https://jekyllrb.com/news/2019/08/20/jekyll-4-0-0-released/#cache-all-the-things- & https://github.com/jekyll/jekyll/releases/tag/v4.0.0

It appears during `make site` & `make serve`.