### PR TITLE
Blockquote paragraphs lack proper space

### DIFF
--- a/assets/css/bootstrap.css
+++ b/assets/css/bootstrap.css
@@ -1484,8 +1484,8 @@ blockquote ul:last-child,
 blockquote ol:last-child {
   margin-bottom: 0;
 }
-blockquote * + p { 
-  padding-bottom: 1em; 
+blockquote :not(h2) + p {
+    padding-top: 1em;
 }
 blockquote footer,
 blockquote small,

--- a/assets/css/bootstrap.css
+++ b/assets/css/bootstrap.css
@@ -1484,6 +1484,9 @@ blockquote ul:last-child,
 blockquote ol:last-child {
   margin-bottom: 0;
 }
+blockquote p { 
+  padding-bottom: 1em; 
+}
 blockquote footer,
 blockquote small,
 blockquote .small {

--- a/assets/css/bootstrap.css
+++ b/assets/css/bootstrap.css
@@ -1484,7 +1484,7 @@ blockquote ul:last-child,
 blockquote ol:last-child {
   margin-bottom: 0;
 }
-blockquote p { 
+blockquote * + p { 
   padding-bottom: 1em; 
 }
 blockquote footer,

--- a/assets/css/bootstrap.css
+++ b/assets/css/bootstrap.css
@@ -1484,9 +1484,6 @@ blockquote ul:last-child,
 blockquote ol:last-child {
   margin-bottom: 0;
 }
-blockquote :not(h2) + p {
-    padding-top: 1em;
-}
 blockquote footer,
 blockquote small,
 blockquote .small {

--- a/assets/css/lesson.scss
+++ b/assets/css/lesson.scss
@@ -148,6 +148,9 @@ font-size: 18px;
 blockquote p {
     margin: 5px;
 }
+blockquote :not(h2) + p {
+    padding-top: 1em;
+}
 
 //----------------------------------------
 // Override Bootstrap settings.


### PR DESCRIPTION
add `blockquote p { padding-bottom: 1em; }` to show paragraph breaks in challenges and call-outs. maintainer discussion indicated that `1em` provided better clarity than `inherit`.

below is a screenshot showing the difference using the **LC Intro to Data** lesson for the example.

![blockquote-current-1em](https://user-images.githubusercontent.com/28507641/63469586-75bf1c80-c41f-11e9-9806-8c57b27e9e5c.png)
