### PR TITLE
use bundler to render lessons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,5 @@ _site
 .Rhistory
 .RData
 .vendor/
+.docker-vendor/
 Gemfile.lock

--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,5 @@ _site
 .Rproj.user
 .Rhistory
 .RData
+.vendor/
 Gemfile.lock

--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,4 @@ _site
 .Rproj.user
 .Rhistory
 .RData
-
+Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,2 @@
+source 'https://rubygems.org'
+gem 'github-pages', group: :jekyll_plugins

--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,10 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
+
+git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
+
+# Synchronize with https://pages.github.com/versions
+ruby '>=2.5.3'
+
 gem 'github-pages', group: :jekyll_plugins

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,8 @@
 # Settings
 MAKEFILES=Makefile $(wildcard *.mk)
 JEKYLL_VERSION=3.8.5
-JEKYLL=bundle update && bundle exec jekyll
 JEKYLL_DOCKER=${JEKYLL} serve --host 0.0.0.0
+JEKYLL=bundle install --path .vendor/bundle && bundle update && bundle exec jekyll
 PARSER=bin/markdown_ast.rb
 DST=_site
 

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,9 @@
 
 # Settings
 MAKEFILES=Makefile $(wildcard *.mk)
-JEKYLL=jekyll
 JEKYLL_VERSION=3.8.5
+JEKYLL=bundle update && bundle exec jekyll
+JEKYLL_DOCKER=${JEKYLL} serve --host 0.0.0.0
 PARSER=bin/markdown_ast.rb
 DST=_site
 
@@ -19,7 +20,7 @@ commands :
 
 ## docker-serve     : use docker to build the site
 docker-serve :
-	docker run --rm -it -v ${PWD}:/srv/jekyll -p 127.0.0.1:4000:4000 jekyll/jekyll:${JEKYLL_VERSION} make serve
+	docker run --rm -it -v ${PWD}:/srv/jekyll -p 4000:4000 jekyll/jekyll:${JEKYLL_VERSION} ${JEKYLL_DOCKER}
 
 ## serve            : run a local server.
 serve : lesson-md

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,6 @@
 # Settings
 MAKEFILES=Makefile $(wildcard *.mk)
 JEKYLL_VERSION=3.8.5
-JEKYLL_DOCKER=${JEKYLL} serve --host 0.0.0.0
 JEKYLL=bundle install --path .vendor/bundle && bundle update && bundle exec jekyll
 PARSER=bin/markdown_ast.rb
 DST=_site
@@ -20,7 +19,11 @@ commands :
 
 ## docker-serve     : use docker to build the site
 docker-serve :
-	docker run --rm -it -v ${PWD}:/srv/jekyll -p 4000:4000 jekyll/jekyll:${JEKYLL_VERSION} ${JEKYLL_DOCKER}
+	docker run --rm -it --volume ${PWD}:/srv/jekyll \
+           --volume=${PWD}/.docker-vendor/bundle:/usr/local/bundle \
+           -p 127.0.0.1:4000:4000 \
+           jekyll/jekyll:${JEKYLL_VERSION} \
+           bin/run-make-docker-serve.sh
 
 ## serve            : run a local server.
 serve : lesson-md

--- a/bin/boilerplate/_config.yml
+++ b/bin/boilerplate/_config.yml
@@ -97,6 +97,7 @@ exclude:
   - bin/
   - .Rproj.user/
   - .vendor/
+  - .docker-vendor/
 
 # Turn on built-in syntax highlighting.
 highlighter: rouge

--- a/bin/boilerplate/_config.yml
+++ b/bin/boilerplate/_config.yml
@@ -96,6 +96,7 @@ exclude:
   - Makefile
   - bin/
   - .Rproj.user/
+  - .vendor/
 
 # Turn on built-in syntax highlighting.
 highlighter: rouge

--- a/bin/run-make-docker-serve.sh
+++ b/bin/run-make-docker-serve.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+
+bundle install
+bundle update
+exec bundle exec jekyll serve --host 0.0.0.0


### PR DESCRIPTION
@carpentries/lesson-infrastructure-committee please provide feedback on this.

- What do you think of including `bundle update` as part of the command that "make" or "serve" the site? including it reduces the chances of getting error messages for missing or outdated dependencies. It's needed with Docker. For Docker, we could use caching and mount the folder that stores the dependencies (https://github.com/envygeeks/jekyll-docker#usage-3) but this works best if the Maintainers (or lesson contributors) only use Docker other the permissions in the folders get messy and it leads to errors. I don't know if people tend to stick to one approach or mix both. (NB: the Docker image we use for Jekyll has bundler installed by default).

- At least on my system, I have to add `--host 0.0.0.0` to the Docker call otherwise I can't access the rendered site.

- In some contexts, it makes sense to commit the Gemfile.lock to the repo, but in ours, I don't think we want to fix the versions of the gems that GitHub Pages is using, instead, we always want to use the latest versions. 
