### PR TITLE
Update R install in .travis.yml

### DIFF
--- a/bin/boilerplate/.travis.yml
+++ b/bin/boilerplate/.travis.yml
@@ -10,13 +10,13 @@ before_install:
   - sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E084DAB9
   - echo "deb https://cloud.r-project.org/bin/linux/ubuntu xenial-cran35/" | sudo tee -a /etc/apt/sources.list
   - sudo apt-get update -y
-  - sudo apt-get install -y --allow-unauthenticated r-base
+  - sudo apt-get install -y r-base
   - sudo Rscript -e "install.packages('knitr', repos = 'https://', dependencies = TRUE)"
   - sudo Rscript -e "install.packages('stringr', repos = 'https://cran.rstudio.com', dependencies = TRUE)"
   - sudo Rscript -e "install.packages('checkpoint', repos = 'https://cran.rstudio.com', dependencies = TRUE)"
   - sudo Rscript -e "install.packages('ggplot2', repos = 'https://cran.rstudio.com', dependencies = TRUE)"
   - rvm default
-  - gem install json kramdown jekyll
+  - gem install json kramdown jekyll bundler
 install:
   - pip install pyyaml
 script:

--- a/bin/boilerplate/.travis.yml
+++ b/bin/boilerplate/.travis.yml
@@ -1,3 +1,4 @@
+# Travis CI is only used to check the lesson and is not involved in its deployment
 dist: xenial  # Ubuntu 16.04 (required for python 3.7)
 language: python
 python: 3.7
@@ -7,9 +8,9 @@ branches:
   - /.*/
 before_install:
   - sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E084DAB9
-  - echo "deb https://cran.rstudio.com/bin/linux/ubuntu trusty/" | sudo tee -a /etc/apt/sources.list
+  - echo "deb https://cloud.r-project.org/bin/linux/ubuntu xenial-cran35/" | sudo tee -a /etc/apt/sources.list
   - sudo apt-get update -y
-  - sudo apt-get install -y r-base
+  - sudo apt-get install -y --allow-unauthenticated r-base
   - sudo Rscript -e "install.packages('knitr', repos = 'https://', dependencies = TRUE)"
   - sudo Rscript -e "install.packages('stringr', repos = 'https://cran.rstudio.com', dependencies = TRUE)"
   - sudo Rscript -e "install.packages('checkpoint', repos = 'https://cran.rstudio.com', dependencies = TRUE)"


### PR DESCRIPTION
Closes #429
Related to #301

I updated the version of R per https://github.com/carpentries/styles/issues/429#issuecomment-531277441 and selected `xenial-cran35` to match the distribution being used to Travis CI.  The comment is for newcomers like me who are trying to figure out how the Travis CI tests relate to the deployment process.

I tested this in [this build](https://travis-ci.org/gitter-lab/ml-bio-workshop/builds/584647245)