### PR TITLE
restore lost CSS settings

### DIFF
--- a/assets/css/bootstrap.css
+++ b/assets/css/bootstrap.css
@@ -1476,7 +1476,7 @@ abbr[data-original-title] {
 blockquote {
   padding: 10px 20px;
   margin: 0 0 20px;
-  font-size: inherit;
+  font-size: 17.5px;
   border-left: 5px solid #eeeeee;
 }
 blockquote p:last-child,

--- a/assets/css/lesson.scss
+++ b/assets/css/lesson.scss
@@ -156,12 +156,19 @@ blockquote :not(h2) + p {
 // Override Bootstrap settings.
 //----------------------------------------
 
+blockquote { font-size: inherit; }
+
 code {
   white-space: nowrap;
   padding: 2px 5px;
   color: #006cad;
   background-color: #e7e7e7;
 }
+
+samp { hyphens: none; }
+
+dt { margin-top: 20px; }
+dd { margin-left: 2em; }
 
 article img {
     display: block;


### PR DESCRIPTION
When we updated bootstrap to 3.4.1 in 6e5cba2, we lost a few settings that we had previously made to `bootstrap.css`. In this PR I'm restoring some of those lost settings.
Others either appear to make no changes or make changes that should be discussed.

Changes explained:

* bootstrap.css
  - restore 17.5px font in blockquote. We override it in `lesson.scss`
* lesson.scss
  - override blockquote font-size
  - disallow hyphens in `samp`
  - set top & left margins in `dt` and `dd` elements, correspondingly (affects "References" page)

Settings omitted in this PR:
- `blockquote pre:last-child { margin-botton: 0; }` as it appears to not affect anything
- `code { color: inherit; }` & `pre { color: inherit; }` as combined they appear to change the default text color of code blocks to match that of the language block (e.g. purple for Python)