### PR TITLE
Enable 'Sponsor' button on GitHub repos

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+github: [carpentries, swcarpentry, datacarpentry, librarycarpentry]
+custom: ["https://carpentries.wedid.it"]


### PR DESCRIPTION
More info at https://help.github.com/en/github/building-a-strong-community/displaying-a-sponsor-button-in-your-repository