### PR TITLE
Makefile: Specify shell. Don't include commands.mk

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+# Use /bin/bash instead of /bin/sh
+export SHELL = /bin/bash
+
 ## ========================================
 ## Commands for both workshop and lesson websites.
 
@@ -142,8 +145,3 @@ lesson-files :
 lesson-fixme :
 	@fgrep -i -n FIXME ${MARKDOWN_SRC} || true
 
-#-------------------------------------------------------------------------------
-# Include extra commands if available.
-#-------------------------------------------------------------------------------
-
--include commands.mk


### PR DESCRIPTION
- Use Bash instead of sh.
- Don't include `commands.mk` at the very end.

I didn't find any repo using `commands.mk`. If there is one/some, we can
keep it.