### PR TITLE
Makefile: use Python to execute repo_check.py

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ site : lesson-md
 
 # repo-check        : check repository settings.
 repo-check :
-	@bin/repo_check.py -s .
+	@${PYTHON} bin/repo_check.py -s .
 
 ## clean            : clean up junk files.
 clean :


### PR DESCRIPTION
We removed executable permission bits from all Python scripts
so we have to use Python to execute them