### PR TITLE
Makefile: improve commands target and commands categories

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,3 @@
-## ========================================
-## Commands for both workshop and lesson websites.
-
 # Settings
 MAKEFILES=Makefile $(wildcard *.mk)
 JEKYLL_VERSION=3.8.5
@@ -34,14 +31,22 @@ endif
 
 # Controls
 .PHONY : commands clean files
-.NOTPARALLEL:
-all : commands
 
-## commands         : show all commands.
-commands :
-	@grep -h -E '^##' ${MAKEFILES} | sed -e "s/## //g"
+# Default target
+.DEFAULT_GOAL := commands
 
-## docker-serve     : use docker to build the site
+## I. Commands for both workshop and lesson websites
+## =================================================
+
+## * serve            : render website and run a local server
+serve : lesson-md
+	${JEKYLL} serve
+
+## * site             : build files but do not run a server
+site : lesson-md
+	${JEKYLL} build
+
+## * docker-serve     : use Docker to serve the site
 docker-serve :
 	docker run --rm -it --volume ${PWD}:/srv/jekyll \
            --volume=${PWD}/.docker-vendor/bundle:/usr/local/bundle \
@@ -49,19 +54,11 @@ docker-serve :
            jekyll/jekyll:${JEKYLL_VERSION} \
            bin/run-make-docker-serve.sh
 
-## serve            : run a local server.
-serve : lesson-md
-	${JEKYLL} serve
-
-## site             : build files but do not run a server.
-site : lesson-md
-	${JEKYLL} build
-
-# repo-check        : check repository settings.
+## * repo-check       : check repository settings
 repo-check :
 	@bin/repo_check.py -s .
 
-## clean            : clean up junk files.
+## * clean            : clean up junk files
 clean :
 	@rm -rf ${DST}
 	@rm -rf .sass-cache
@@ -70,22 +67,26 @@ clean :
 	@find . -name '*~' -exec rm {} \;
 	@find . -name '*.pyc' -exec rm {} \;
 
-## clean-rmd        : clean intermediate R files (that need to be committed to the repo).
+## * clean-rmd        : clean intermediate R files (that need to be committed to the repo)
 clean-rmd :
 	@rm -rf ${RMD_DST}
 	@rm -rf fig/rmd-*
 
-## ----------------------------------------
-## Commands specific to workshop websites.
+
+##
+## II. Commands specific to workshop websites
+## =================================================
 
 .PHONY : workshop-check
 
-## workshop-check   : check workshop homepage.
+## * workshop-check   : check workshop homepage
 workshop-check :
 	@${PYTHON} bin/workshop_check.py .
 
-## ----------------------------------------
-## Commands specific to lesson websites.
+
+##
+## III. Commands specific to lesson websites
+## =================================================
 
 .PHONY : lesson-check lesson-md lesson-files lesson-fixme
 
@@ -113,34 +114,43 @@ HTML_DST = \
   $(patsubst _extras/%.md,${DST}/%/index.html,$(sort $(wildcard _extras/*.md))) \
   ${DST}/license/index.html
 
-## lesson-md        : convert Rmarkdown files to markdown
+## * lesson-md        : convert Rmarkdown files to markdown
 lesson-md : ${RMD_DST}
 
 _episodes/%.md: _episodes_rmd/%.Rmd
 	@bin/knit_lessons.sh $< $@
 
-## lesson-check     : validate lesson Markdown.
+# * lesson-check     : validate lesson Markdown
 lesson-check : lesson-fixme
 	@${PYTHON} bin/lesson_check.py -s . -p ${PARSER} -r _includes/links.md
 
-## lesson-check-all : validate lesson Markdown, checking line lengths and trailing whitespace.
+## * lesson-check-all : validate lesson Markdown, checking line lengths and trailing whitespace
 lesson-check-all :
 	@${PYTHON} bin/lesson_check.py -s . -p ${PARSER} -r _includes/links.md -l -w --permissive
 
-## unittest         : run unit tests on checking tools.
+## * unittest         : run unit tests on checking tools
 unittest :
 	@${PYTHON} bin/test_lesson_check.py
 
-## lesson-files     : show expected names of generated files for debugging.
+## * lesson-files     : show expected names of generated files for debugging
 lesson-files :
 	@echo 'RMD_SRC:' ${RMD_SRC}
 	@echo 'RMD_DST:' ${RMD_DST}
 	@echo 'MARKDOWN_SRC:' ${MARKDOWN_SRC}
 	@echo 'HTML_DST:' ${HTML_DST}
 
-## lesson-fixme     : show FIXME markers embedded in source files.
+## * lesson-fixme     : show FIXME markers embedded in source files
 lesson-fixme :
 	@fgrep -i -n FIXME ${MARKDOWN_SRC} || true
+
+##
+## IV. Auxililary (plumbing) commands
+## =================================================
+
+## * commands         : show all commands.
+commands :
+	@sed -n -e '/^##/s|^##[[:space:]]*||p' $(MAKEFILE_LIST)
+
 
 #-------------------------------------------------------------------------------
 # Include extra commands if available.

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ endif
 serve : lesson-md
 	${JEKYLL} serve
 
-## * site             : build files but do not run a server
+## * site             : build website but do not run a server
 site : lesson-md
 	${JEKYLL} build
 


### PR DESCRIPTION
Rewrote `commands` target (removed pipe from it) -- tested on macOS and Windows.

Also, added `*` to target names and Roman numerals to command categories