### PR TITLE
update LICENSE and COC links

### DIFF
--- a/bin/boilerplate/CONTRIBUTING.md
+++ b/bin/boilerplate/CONTRIBUTING.md
@@ -10,12 +10,12 @@ and reviews of proposed changes are all welcome.
 ## Contributor Agreement
 
 By contributing,
-you agree that we may redistribute your work under [our license](LICENSE.md).
+you agree that we may redistribute your work under [our license](../../LICENSE.md).
 In exchange,
 we will address your issues and/or assess your change proposal as promptly as we can,
 and help you become a member of our community.
 Everyone involved in [The Carpentries][c-site]
-agrees to abide by our [code of conduct](CODE_OF_CONDUCT.md).
+agrees to abide by our [code of conduct](../../CODE_OF_CONDUCT.md).
 
 ## How to Contribute
 


### PR DESCRIPTION
Since the user is always directed here, the links should point to the correct pages. The COC link is a bit bare, however since the relevant content is Jekyll-derived. Maybe we should just link the Carpentries code of conduct instead?