### PR TITLE
Improve issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,11 +1,21 @@
-Please delete this line and the text below before submitting your contribution.
+<details>
+<summary>Instructions</summary>
 
----
+Thanks for contributing! :heart:
 
-Thanks for contributing! If this contribution is for instructor training, please send an email to checkout@carpentries.org with a link to this contribution so we can record your progress. You’ve completed your contribution step for instructor checkout just by submitting this contribution.  
+If this contribution is for instructor training, please email link to this contribution to
+checkout@carpentries.org so we can record your progress. You've completed your contribution
+step for instructor checkout by submitting this contribution!
 
 If this issue is about a specific episode within a lesson, please provide its link or filename.
 
-Please keep in mind that lesson maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum.  If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact The Carpentries Team at team@carpentries.org.  
+Keep in mind that **lesson maintainers are volunteers** and it may take them some time to
+respond to your contribution. Although not all contributions can be incorporated into the lesson
+materials, we appreciate your time and effort to improve the curriculum. If you have any questions
+about the lesson maintenance process or would like to volunteer your time as a contribution
+reviewer, please contact The Carpentries Team at team@carpentries.org.
 
----
+You may delete these instructions from your comment.
+
+- The Carpentries
+</details>

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -3,7 +3,7 @@
 
 Thanks for contributing! :heart:
 
-If this contribution is for instructor training, please email link to this contribution to
+If this contribution is for instructor training, please email the link to this contribution to
 checkout@carpentries.org so we can record your progress. You've completed your contribution
 step for instructor checkout by submitting this contribution!
 

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -17,5 +17,5 @@ reviewer, please contact The Carpentries Team at team@carpentries.org.
 
 You may delete these instructions from your comment.
 
-- The Carpentries
+\- The Carpentries
 </details>

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,5 +1,5 @@
 <details>
-<summary>Instructions</summary>
+<summary><strong>Instructions</strong></summary>
 
 Thanks for contributing! :heart:
 


### PR DESCRIPTION
I suggest using `<details>` to provide general instructions for GitHub issues. Advantage: if contributors don't delete it, it'll be hidden though they will still see the text when they create an issue. Here is how it's going to look:

<details>
<summary><strong>Instructions</strong></summary>

Thanks for contributing! :heart:

If this contribution is for instructor training, please email link to this contribution to
checkout@carpentries.org so we can record your progress. You've completed your contribution
step for instructor checkout by submitting this contribution!

If this issue is about a specific episode within a lesson, please provide its link or filename.

Keep in mind that **lesson maintainers are volunteers** and it may take them some time to
respond to your contribution. Although not all contributions can be incorporated into the lesson
materials, we appreciate your time and effort to improve the curriculum. If you have any questions
about the lesson maintenance process or would like to volunteer your time as a contribution
reviewer, please contact The Carpentries Team at team@carpentries.org.

You may delete these instructions from your comment.

\- The Carpentries
</details>
