### PR TITLE
lesson.scss: style tab panels on setup pages

### DIFF
--- a/assets/css/lesson.scss
+++ b/assets/css/lesson.scss
@@ -76,6 +76,13 @@ $color-testimonial: #fc8dc1 !default;
 .r::before, .language-r::before { content: "R"; }
 .sql::before, .language-sql::before { content: "SQL"; }
 
+// Tab panels are used on Setup pages to show instructions for different Operating Systems
+.tab-pane {
+  border: solid 1px #ddd; // #ddd == @nav-tabs-active-link-hover-border-color
+  border-top: none;
+  padding: 20px 20px 10px 20px;
+  border-radius: 0 0 4px 4px; // 4px == @border-radius-base
+}
 
 //----------------------------------------
 // Specialized blockquote environments for learning objectives, callouts, etc.


### PR DESCRIPTION
Improve styling of tab panels on setup pages:

Before
<img width="1170" alt="image" src="https://user-images.githubusercontent.com/13123663/85129650-12497b00-b1f9-11ea-81ba-626ff2266898.png">

After:

<img width="1170" alt="image" src="https://user-images.githubusercontent.com/13123663/85129592-f940ca00-b1f8-11ea-9f38-d58515da1b51.png">
